### PR TITLE
Add light/dark mode toggle

### DIFF
--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('theme-toggle');
+  const root = document.documentElement;
+
+  function applyTheme(theme) {
+    if (theme === 'dark') {
+      root.setAttribute('data-theme', 'dark');
+    } else {
+      root.removeAttribute('data-theme');
+    }
+  }
+
+  const stored = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const initial = stored || (prefersDark ? 'dark' : 'light');
+  applyTheme(initial);
+
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      const isDark = root.getAttribute('data-theme') === 'dark';
+      const newTheme = isDark ? 'light' : 'dark';
+      applyTheme(newTheme);
+      localStorage.setItem('theme', newTheme);
+    });
+  }
+});
+

--- a/style.css
+++ b/style.css
@@ -8,8 +8,6 @@
   padding: 0;
   box-sizing: border-box;
 }
-*/
-
 /* 2. Custom Properties (Theme) */
 :root {
   /* Base colour palette */
@@ -26,12 +24,23 @@
   --max-width:        800px;
   --gap:              1rem;
 }
+[data-theme="dark"] {
+  --color-background: #1e1e1e;
+  --color-surface: #2c2c2c;
+  --color-text: #e4e4e4;
+  --color-muted: #aaaaaa;
+  --color-accent: #a78bfa;
+  --color-accent-hover: #c4b5fd;
+  --color-border: #444444;
+}
+
 
 /* 3. Base Styles */
 html {
   font-family: var(--font-sans);
   line-height: var(--line-height);
   font-size: 16px;
+  transition: background 0.3s, color 0.3s;
   background: var(--color-background);
   color: var(--color-text);
 }
@@ -307,3 +316,9 @@ code {
   .hero { padding: 3rem 1rem; }
 }
 
+#theme-toggle { cursor: pointer; }
+
+
+@media (max-width: 640px) {
+  .container { width: 100%; padding: var(--gap); }
+}

--- a/templates/basic_template.html
+++ b/templates/basic_template.html
@@ -20,12 +20,15 @@
 
 </head>
 <body>
-  <nav class="bg-purple-700 text-white shadow mb-4">
-    <div class="max-w-3xl mx-auto flex items-center justify-between p-4">
-      <a class="font-semibold text-lg" href="/">My Learning Log</a>
-      <a class="text-sm hover:underline" href="/atom.xml">RSS Feed</a>
-    </div>
-  </nav>
+    <nav class="bg-purple-700 text-white shadow mb-4">
+      <div class="max-w-3xl mx-auto flex flex-col sm:flex-row items-center justify-between p-4 gap-2">
+        <a class="font-semibold text-lg" href="/">My Learning Log</a>
+        <div class="flex items-center gap-4">
+          <a class="text-sm hover:underline" href="/atom.xml">RSS Feed</a>
+          <button id="theme-toggle" class="text-sm border border-white rounded px-2 py-1">Toggle</button>
+        </div>
+      </div>
+    </nav>
 
   <div class="max-w-3xl mx-auto p-4 flex-grow">
     <!-- The old header is removed, navbar serves as header -->
@@ -108,6 +111,7 @@
   <script id="dsq-count-scr" src="//hamishsblog.disqus.com/count.js" async></script>
   <script src="/js/pagination.js" defer></script>
   <script src="/js/sharing.js" defer></script>
+  <script src="/js/theme-toggle.js" defer></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- add dark theme variables and smooth colour transitions
- tweak nav layout for small screens and include colour mode button
- copy new JS for toggling themes
- minor responsive CSS improvements

## Testing
- `./build.sh` *(fails: pandoc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416bcd32c0832ead7d48c549d9dd5b